### PR TITLE
Add pub keyword to TensorIndexer fields

### DIFF
--- a/src/common/shape.rs
+++ b/src/common/shape.rs
@@ -7,13 +7,13 @@ use crate::common::proto::common::{tensor_shape, TensorShape};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub struct TensorIndexer {
-    ho_stride: usize,
-    co_stride: usize,
-    hi_stride: usize,
-    ci_stride: usize,
-    w_stride: usize,
-    hi_limit: usize,
-    ci_limit: usize,
+    pub ho_stride: usize,
+    pub co_stride: usize,
+    pub hi_stride: usize,
+    pub ci_stride: usize,
+    pub w_stride: usize,
+    pub hi_limit: usize,
+    pub ci_limit: usize,
 }
 
 impl<'a> From<&'a TensorShape> for TensorIndexer {


### PR DESCRIPTION
외부 crate에서 TensorIndexer를 직접 생성하거나 필드를 얻을 수 있게 합니다.