### PR TITLE
Update dependencies & follow new pyo3 APIs

### DIFF
--- a/.ci/task.yml
+++ b/.ci/task.yml
@@ -17,7 +17,7 @@ spec:
   params:
     - name: image
       description: The container image to use black in
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/mlperf-postprocess:221102
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/mlperf-postprocess:230421
   steps:
     - name: format
       env:
@@ -57,7 +57,7 @@ spec:
   params:
     - name: image
       description: The container image to use black in
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/mlperf-postprocess:221102
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/mlperf-postprocess:230421
   steps:
     - name: unittest
       env:
@@ -96,7 +96,7 @@ spec:
   params:
     - name: image
       description: The container image to use black in
-      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/mlperf-postprocess:221102
+      default: asia-northeast3-docker.pkg.dev/next-gen-infra/furiosa-ai/mlperf-postprocess:230421
   steps:
     - name: build-wheel
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,19 +12,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "atty"
@@ -68,34 +48,34 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cbindgen"
-version = "0.20.0"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e3973b165dc0f435831a9e426de67e894de532754ff7a3f307c03ee5dec7dc"
+checksum = "a6358dedf60f4d9b8db43ad187391afe959746101346fe51bb978126bec61dfb"
 dependencies = [
  "clap",
- "heck 0.3.3",
+ "heck",
  "indexmap",
  "log",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "toml",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -105,17 +85,26 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_lex",
+ "indexmap",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -138,7 +127,7 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "regex",
- "syn",
+ "syn 1.0.109",
  "unicode-xid",
 ]
 
@@ -150,7 +139,7 @@ checksum = "76071bb9c8c4dd2b5eb209907deab7b031323cf1be3dfdc6ec5d37f4f187d8a1"
 dependencies = [
  "lazy_static",
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -165,29 +154,29 @@ dependencies = [
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "crc"
-version = "2.1.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49fc9a695bca7f35f5f4c15cddc84415f66a74ea78eef08e90c5024f2b540e23"
+checksum = "86ec7a15cbe22e59248fc7eadb1907dab5ba09372595da4d73dd805ed4417dfe"
 dependencies = [
  "crc-catalog",
 ]
 
 [[package]]
 name = "crc-catalog"
-version = "1.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccaeedb56da03b09f598226e25e80088cb4cd25f316e6e4df7d695f0feeb1403"
+checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -195,9 +184,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -206,31 +195,52 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.13"
+version = "0.9.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
 dependencies = [
  "autocfg",
  "cfg-if",
  "crossbeam-utils",
- "memoffset 0.7.1",
+ "memoffset",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.14"
+version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "either"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "eyre"
@@ -244,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
 dependencies = [
  "instant",
 ]
@@ -281,17 +291,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,18 +298,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "heck"
-version = "0.3.3"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "heck"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -331,6 +321,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,9 +334,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -348,9 +344,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da2d6f23ffea9d7e76c53eee25dfb67bcd8fde7f1198b0855350698c9f07c780"
+checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
 
 [[package]]
 name = "instant"
@@ -359,6 +355,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -372,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
 
 [[package]]
 name = "lazy_static"
@@ -384,9 +391,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "lock_api"
@@ -433,18 +446,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -481,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
 dependencies = [
  "num-traits",
 ]
@@ -530,24 +534,24 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.17.2"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a462c1af5ba1fddec1488c4646993a23ae7931f9e170ccba23e9c7c834277797"
+checksum = "96b0fee4571867d318651c24f4a570c3f18408cf95f16ccb576b3ce85496a46e"
 dependencies = [
- "ahash",
  "libc",
  "ndarray",
  "num-complex",
  "num-integer",
  "num-traits",
  "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openmp-sys"
@@ -557,6 +561,12 @@ checksum = "a3a0ed77d2794d2b9a59123e60e874190626c22b7124ce38959fe59386e317fa"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
 
 [[package]]
 name = "parking_lot"
@@ -570,22 +580,22 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ff9f3fef3968a3ec5945535ed654cb38ff72d7495a25619e2247fb15a2ed9ba"
+checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d5014253a1331579ce62aa67443b4a658c5e7dd03d4bc6d302b94474888143"
+checksum = "4dd7d28ee937e54fe3080c91faa1c3a46c06de6252988a7f4592ba2310ef22a4"
 dependencies = [
  "fixedbitset",
  "indexmap",
@@ -599,28 +609,28 @@ checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "prettyplease"
-version = "0.1.22"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8992a85d8e93a28bdf76137db888d3874e3b230dee5ed8bebac4c9f7617773"
+checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c01db6702aa05baa3f57dec92b8eeeeb4cb19e894e73996b32a4093289e54592"
+checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -628,12 +638,12 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb5320c680de74ba083512704acb90fe00f28f79207286a848e730c45dd73ed6"
+checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
 dependencies = [
  "bytes",
- "heck 0.4.0",
+ "heck",
  "itertools",
  "lazy_static",
  "log",
@@ -643,44 +653,43 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 1.0.109",
  "tempfile",
  "which",
 ]
 
 [[package]]
 name = "prost-derive"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8842bad1a5419bca14eac663ba798f6bc19c413c2fdceb5f3ba3b0932d96720"
+checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
 dependencies = [
  "anyhow",
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "prost-types"
-version = "0.11.5"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "017f79637768cde62820bc2d4fe0e45daaa027755c323ad077767c6c5f173091"
+checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
 dependencies = [
- "bytes",
  "prost",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "268be0c73583c183f2b14052337465768c07726936a260f480f0857cb95ba543"
+checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
- "memoffset 0.6.5",
+ "memoffset",
  "parking_lot",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -690,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28fcd1e73f06ec85bf3280c48c67e731d8290ad3d730f8be9dc07946923005c8"
+checksum = "98a42e7f42e917ce6664c832d5eee481ad514c98250c49e0b03b20593e2c7ed0"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -700,9 +709,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6cb136e222e49115b3c51c32792886defbfb0adead26a688142b346a0b9ffc"
+checksum = "a0707f0ab26826fe4ccd59b69106e9df5e12d097457c7b8f9c0fd1d2743eec4d"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -710,32 +719,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94144a1266e236b1c932682136dc35a9dee8d3589728f68130c7c3861ef96b28"
+checksum = "978d18e61465ecd389e1f235ff5a467146dc4e3c3968b90d274fe73a5dd4a438"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.17.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8df9be978a2d2f0cdebabb03206ed73b11314701a5bfe71b0d753b81997777f"
+checksum = "8e0e1128f85ce3fca66e435e08aa2089a2689c1c48ce97803e13f63124058462"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -754,9 +763,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
 dependencies = [
  "either",
  "rayon-core",
@@ -764,9 +773,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac410af5d00ab6884528b4ab69d1e8e146e8d471201800fa1b4524126de6ad3"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -785,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -796,18 +805,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
-
-[[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "rulinalg"
@@ -820,10 +820,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.12"
+name = "rustc-hash"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustix"
+version = "0.36.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
 
 [[package]]
 name = "scopeguard"
@@ -833,29 +853,29 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.151"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fed41fc1a24994d044e6db6935e69511a1153b52c15eb42493b26fa87feba0"
+checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.151"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255abe9a125a985c05190d687b320c12f9b1f0b99445e608c21ba0782c719ad8"
+checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.10",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
 dependencies = [
  "itoa",
  "ryu",
@@ -870,15 +890,26 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -887,38 +918,43 @@ dependencies = [
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.5"
+version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9410d0f6853b1d94f0e519fb95df60f29d2c1eff2d921ffdf01a4c8a3b54f12d"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
  "cfg-if",
  "fastrand",
- "libc",
  "redox_syscall",
- "remove_dir_all",
- "winapi",
+ "rustix",
+ "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "toml"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
+checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
 dependencies = [
  "serde",
 ]
@@ -943,7 +979,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -957,21 +993,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
-
-[[package]]
-name = "unicode-width"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
 
 [[package]]
 name = "unicode-xid"
@@ -986,28 +1010,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
-name = "version_check"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
 name = "which"
-version = "4.3.0"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
 dependencies = [
  "either",
  "libc",
@@ -1031,6 +1037,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,43 +1067,67 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,52 +118,52 @@ dependencies = [
 
 [[package]]
 name = "cpp"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec5e86d4f6547f0218ad923d9508244a71ef83b763196e6698b4f70f3595185"
+checksum = "43b6a1d47f376a62bbea281408fe331879b9822c1edb8f67320c7cb8d96a02eb"
 dependencies = [
  "cpp_macros",
 ]
 
 [[package]]
 name = "cpp_build"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f4d303b8ec35fb3afd7e963e2c898117f1e49930becb703e4a7ac528ad2dd0"
+checksum = "5b8f839b67a3deba30b58b281b5fca61477a90830beb084c58bdb9bebd227a1a"
 dependencies = [
  "cc",
  "cpp_common",
  "lazy_static",
  "proc-macro2",
  "regex",
- "syn 1.0.109",
+ "syn 2.0.15",
  "unicode-xid",
 ]
 
 [[package]]
 name = "cpp_common"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76071bb9c8c4dd2b5eb209907deab7b031323cf1be3dfdc6ec5d37f4f187d8a1"
+checksum = "42d2b968b7b2ac412836e8ce1dfc3dfd5648ae7e8a42fcbbf5bc1d33bb795b0d"
 dependencies = [
  "lazy_static",
  "proc-macro2",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "cpp_macros"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdaa01904c12a8989dbfa110b41ef27efc432ac9934f691b9732f01cb64dc01"
+checksum = "5d36d9acb58020380e756d56a8dfc84d0f6ace423bbd4fedf83992b257b7f147"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "byteorder",
  "cpp_common",
  "lazy_static",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -174,9 +183,9 @@ checksum = "9cace84e55f07e7301bae1c519df89cdad8cc3cd868413d3fdbdeca9ff3db484"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -223,13 +232,13 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -359,13 +368,13 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.9"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09270fd4fa1111bc614ed2246c7ef56239a3063d5be0d1ec3b589c505d400aeb"
+checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
  "hermit-abi 0.3.1",
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -391,15 +400,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.140"
+version = "0.2.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
 
 [[package]]
 name = "lock_api"
@@ -431,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+checksum = "bb99c395ae250e1bf9133673f03ca9f97b7e71b705436bf8f089453445d1e9fe"
 dependencies = [
  "rawpointer 0.2.1",
 ]
@@ -465,7 +474,7 @@ version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
 dependencies = [
- "matrixmultiply 0.3.2",
+ "matrixmultiply 0.3.3",
  "num-complex",
  "num-integer",
  "num-traits",
@@ -586,7 +595,7 @@ checksum = "9069cbb9f99e3a5083476ccb29ceb1de18b9118cafa53e90c9551235de2b9521"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "windows-sys 0.45.0",
 ]
@@ -619,18 +628,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prost"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48e50df39172a3e7eb17e14642445da64996989bc212b583015435d39a58537"
+checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -638,9 +647,9 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c828f93f5ca4826f97fedcbd3f9a536c16b12cff3dbbb4a007f932bbad95b12"
+checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes",
  "heck",
@@ -660,9 +669,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea9b0f8cbe5e15a8a042d030bd96668db28ecb567ec37d691971ff5731d2b1b"
+checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
  "itertools",
@@ -673,18 +682,18 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.11.8"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379119666929a1afd7a043aa6cf96fa67a6dce9af60c88095a4686dbce4c9c88"
+checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
  "prost",
 ]
 
 [[package]]
 name = "pyo3"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb848f80438f926a9ebddf0a539ed6065434fd7aae03a89312a9821f81b8501"
+checksum = "e3b1ac5b3731ba34fdaa9785f8d74d17448cd18f30cf19e0c7e7b1fdb5272109"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -699,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a42e7f42e917ce6664c832d5eee481ad514c98250c49e0b03b20593e2c7ed0"
+checksum = "9cb946f5ac61bb61a5014924910d936ebd2b23b705f7a4a3c40b05c720b079a3"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -709,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0707f0ab26826fe4ccd59b69106e9df5e12d097457c7b8f9c0fd1d2743eec4d"
+checksum = "fd4d7c5337821916ea2a1d21d1092e8443cf34879e53a0ac653fbb98f44ff65c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -719,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978d18e61465ecd389e1f235ff5a467146dc4e3c3968b90d274fe73a5dd4a438"
+checksum = "a9d39c55dab3fc5a4b25bbd1ac10a2da452c4aca13bb450f22818a002e29648d"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -731,9 +740,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.18.2"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0e1128f85ce3fca66e435e08aa2089a2689c1c48ce97803e13f63124058462"
+checksum = "97daff08a4c48320587b5224cc98d609e3c27b6d437315bd40b605c98eeb5918"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -793,21 +802,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.7.3"
+name = "redox_syscall"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "aho-corasick",
+ "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6cf59af1067a3fb53fbe5c88c053764e930f932be1d71d3ffe032cbe147f59"
+dependencies = [
+ "aho-corasick 1.0.1",
  "memchr",
  "regex-syntax",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.29"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+checksum = "b6868896879ba532248f33598de5181522d8b3d9d724dfd230911e1a7d4822f5"
 
 [[package]]
 name = "rulinalg"
@@ -827,16 +845,16 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
-version = "0.36.11"
+version = "0.37.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4165c9963ab29e422d6c26fbc1d37f15bace6b2810221f9d925023480fcf0e"
+checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
 dependencies = [
  "bitflags",
  "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -853,29 +871,29 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "serde"
-version = "1.0.158"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771d4d9c4163ee138805e12c710dd365e4f44be8be0503cb1bb9eb989425d9c9"
+checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.158"
+version = "1.0.160"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
+checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.10",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -907,9 +925,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.10"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aad1363ed6d37b84299588d62d3a7d95b5a5c2d9aad5c85609fda12afaa1f40"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -924,15 +942,15 @@ checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
- "windows-sys 0.42.0",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -1053,26 +1071,20 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.42.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -1081,13 +1093,28 @@ version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1097,10 +1124,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1109,10 +1148,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1121,13 +1172,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,7 +278,7 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "furiosa-native-postprocess"
-version = "0.2.2"
+version = "0.9.0"
 dependencies = [
  "cbindgen",
  "cpp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,21 +16,21 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cpp = { version = "0.5.7", optional = true }
-crc = "2.1.0"
+crc = "3.0.1"
 eyre = "0.6.8"
-indexmap = "1.9.2"
+indexmap = "1.9.3"
 itertools = "0.10.5"
 lazy_static = "1.4.0"
-ndarray = { version = "0.15.0" }
-numpy = "0.17.2"
+ndarray = { version = "0.15.6" }
+numpy = "0.18.0"
 openmp-sys = "1.2.3"
-prost = "0.11.5"
-pyo3 = { version = "0.17.3", features = ["extension-module"] }
-rayon = "1.6.1"
+prost = "0.11.8"
+pyo3 = { version = "0.18.2", features = ["extension-module"] }
+rayon = "1.7.0"
 rulinalg = "0.4.2"
 tracing = "0.1.37"
 
 [build-dependencies]
-cbindgen = { version = "0.20.0", optional = true }
+cbindgen = { version = "0.24.3", optional = true }
 cpp_build = { version = "0.5.7", optional = true }
-prost-build = "0.11.5"
+prost-build = "0.11.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "furiosa_native_postprocess"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-cpp = { version = "0.5.7", optional = true }
+cpp = { version = "0.5.8", optional = true }
 crc = "3.0.1"
 eyre = "0.6.8"
 indexmap = "1.9.3"
@@ -24,13 +24,13 @@ lazy_static = "1.4.0"
 ndarray = { version = "0.15.6" }
 numpy = "0.18.0"
 openmp-sys = "1.2.3"
-prost = "0.11.8"
-pyo3 = { version = "0.18.2", features = ["extension-module"] }
+prost = "0.11.9"
+pyo3 = { version = "0.18.3", features = ["extension-module"] }
 rayon = "1.7.0"
 rulinalg = "0.4.2"
 tracing = "0.1.37"
 
 [build-dependencies]
 cbindgen = { version = "0.24.3", optional = true }
-cpp_build = { version = "0.5.7", optional = true }
-prost-build = "0.11.8"
+cpp_build = { version = "0.5.8", optional = true }
+prost-build = "0.11.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "furiosa-native-postprocess"
-version = "0.2.2"
+version = "0.9.0"
 edition = "2021"
 build = "build.rs"
 exclude = ["models"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash -o pipefail
 
-TOOLCHAIN_VERSION=0.8.0-2
-ONNXRUNTIME_VERSION=1.12.1-2
+TOOLCHAIN_VERSION=0.9.0-2
+ONNXRUNTIME_VERSION=1.13.1-2
 
 .PHONY: install-deps lint test
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,21 @@
-SHELL=/bin/bash -o pipefail
+SHELL := /bin/bash -o pipefail
 
-.PHONY: toolchain lint test
+TOOLCHAIN_VERSION=0.8.0-2
+ONNXRUNTIME_VERSION=1.12.1-2
+
+.PHONY: install-deps lint test
 
 check-docker-tag:
 ifndef DOCKER_TAG
 	$(error "DOCKER_TAG is not set")
 endif
 
-toolchain:
+install-deps:
+	apt-get install -y --allow-downgrades furiosa-libhal-warboy \
+		libonnxruntime=$(ONNXRUNTIME_VERSION) \
+		furiosa-libcompiler=$(TOOLCHAIN_VERSION) \
+		furiosa-libnux-extrinsic=$(TOOLCHAIN_VERSION) \
+		furiosa-libnux=$(TOOLCHAIN_VERSION)
 
 lint:
 	cargo fmt --all --check \

--- a/build.rs
+++ b/build.rs
@@ -26,7 +26,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .build("src/lib.rs");
     }
 
-    let proto_files = &["npu_ir/dfg.proto", "npu_ir/common.proto"];
+    let proto_files = &[
+        "npu_ir/dfg.proto",
+        "npu_ir/element_type.proto",
+        "npu_ir/shape.proto",
+        "npu_ir/tensor.proto",
+    ];
     let mut prost_config = prost_build::Config::new();
     let proto_includes = if let Ok(path) = std::env::var("NPU_TOOLS_PATH") {
         vec![PathBuf::from(path).join("crates/npu-ir/protos_generated/")]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,8 +2,8 @@ FROM rust:1-slim-bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-RUN rustup toolchain install nightly-2022-01-09-x86_64-unknown-linux-gnu
-RUN rustup component add rustfmt clippy --toolchain nightly-2022-01-09-x86_64-unknown-linux-gnu
+RUN rustup toolchain install nightly-2023-02-01-x86_64-unknown-linux-gnu
+RUN rustup component add rustfmt clippy --toolchain nightly-2023-02-01-x86_64-unknown-linux-gnu
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         build-essential pkg-config git vim \
@@ -18,8 +18,8 @@ RUN echo "deb [arch=amd64] https://internal-archive.furiosa.dev/ubuntu focal res
     echo "deb [arch=amd64] https://internal-archive.furiosa.dev/ubuntu focal-nightly restricted" \
         >> /etc/apt/sources.list.d/furiosa.list
 
-ARG TOOLCHAIN_VERSION=0.8.0-2
-ARG ONNXRUNTIME_VERSION=1.12.1-2
+ARG TOOLCHAIN_VERSION=0.9.0-2
+ARG ONNXRUNTIME_VERSION=1.13.1-2
 
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5F03AFA423A751913F249259814F888B20B09A7E
 RUN --mount=type=secret,id=furiosa.conf,dst=/etc/apt/auth.conf.d/furiosa.conf,required \

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2022-11-21"
+channel = "nightly-2023-02-01"

--- a/src/common/graph.rs
+++ b/src/common/graph.rs
@@ -6,19 +6,19 @@ use prost::Message;
 
 use super::model::{ModelOutputInfo, TensorMeta};
 use crate::common::model::{ElementType, QuantizationParameter};
-use crate::common::proto::{self, dfg};
+use crate::common::proto;
 use crate::common::shape::TensorIndexer;
 
 pub type TensorIndex = u32;
 
-impl<'a> From<&'a proto::common::ElementType> for ElementType {
-    fn from(element_type: &'a proto::common::ElementType) -> Self {
+impl<'a> From<&'a proto::element_type::ElementType> for ElementType {
+    fn from(element_type: &'a proto::element_type::ElementType) -> Self {
         match element_type.inner.as_ref().unwrap() {
-            proto::common::element_type::Inner::Int8(inner) => {
+            proto::element_type::element_type::Inner::Int8(inner) => {
                 let quantization_info = inner.quantization_info.as_ref().unwrap();
                 assert_eq!(quantization_info.quantization_parameters.len(), 1);
 
-                let proto::common::QuantizationParameter { min, max } =
+                let proto::element_type::QuantizationParameter { min, max } =
                     quantization_info.quantization_parameters[0];
 
                 let scale = (max - min) / (i8::max_value() as f64 - i8::min_value() as f64);
@@ -36,8 +36,8 @@ pub struct TensorInfo {
     element_type: ElementType,
 }
 
-impl<'a> From<&'a proto::common::Tensor> for TensorInfo {
-    fn from(tensor: &'a proto::common::Tensor) -> Self {
+impl<'a> From<&'a proto::tensor::Tensor> for TensorInfo {
+    fn from(tensor: &'a proto::tensor::Tensor) -> Self {
         Self {
             shape: tensor.shape.as_ref().unwrap().into(),
             element_type: tensor.element_type.as_ref().unwrap().into(),
@@ -58,7 +58,7 @@ impl TensorInfo {
 #[derive(Debug, Clone)]
 pub struct GraphInfo {
     pub outputs: Vec<TensorIndex>,
-    pub tensors: HashMap<TensorIndex, proto::common::Tensor>,
+    pub tensors: HashMap<TensorIndex, proto::tensor::Tensor>,
 }
 
 #[allow(clippy::from_over_into)]
@@ -83,13 +83,13 @@ impl<'a> Into<ModelOutputInfo> for &'a GraphInfo {
 }
 
 pub fn create_graph_from_binary(input: &[u8]) -> eyre::Result<GraphInfo> {
-    let graph = dfg::Graph::decode(input)?;
+    let graph = proto::dfg::Graph::decode(input)?;
 
     let tensors = graph
         .tensors
         .iter()
         .map(|(&tensor_index, tensor)| (tensor_index, tensor.clone()))
-        .collect::<HashMap<TensorIndex, proto::common::Tensor>>();
+        .collect::<HashMap<TensorIndex, proto::tensor::Tensor>>();
 
     Ok(GraphInfo { outputs: graph.outputs, tensors })
 }

--- a/src/common/graph.rs
+++ b/src/common/graph.rs
@@ -25,7 +25,18 @@ impl<'a> From<&'a proto::element_type::ElementType> for ElementType {
                 let zero_point = i8::min_value() as i32 - (min / scale).round() as i32;
                 Self::Int8 { quantization_parameter: QuantizationParameter { scale, zero_point } }
             }
-            _ => unimplemented!("Only Int8 output type supported"),
+            proto::element_type::element_type::Inner::Uint8(inner) => {
+                let quantization_info = inner.quantization_info.as_ref().unwrap();
+                assert_eq!(quantization_info.quantization_parameters.len(), 1);
+
+                let proto::element_type::QuantizationParameter { min, max } =
+                    quantization_info.quantization_parameters[0];
+
+                let scale = (max - min) / (u8::max_value() as f64 - u8::min_value() as f64);
+                let zero_point = u8::min_value() as i32 - (min / scale).round() as i32;
+                Self::Uint8 { quantization_parameter: QuantizationParameter { scale, zero_point } }
+            }
+            _ => unimplemented!("Only Int8/Uint8 output type supported"),
         }
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -58,11 +58,11 @@ pub struct PyDetectionResult {
 #[pymethods]
 impl PyDetectionResult {
     fn __repr__(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 
     fn __str__(&self) -> String {
-        format!("{:?}", self)
+        format!("{self:?}")
     }
 }
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -5,7 +5,7 @@ pub mod shape;
 pub mod ssd_postprocess;
 
 use numpy::PyArrayDyn;
-use pyo3::{self, exceptions::PyValueError, pyclass, pymethods, types::PyList, PyErr, PyResult};
+use pyo3::{self, exceptions::PyValueError, pyclass, pymethods, types::PyList, PyResult};
 use ssd_postprocess::{DetectionResult, DetectionResults};
 
 #[pyclass]
@@ -94,9 +94,7 @@ pub(crate) fn convert_to_slices(inputs: &PyList) -> PyResult<Vec<&[u8]>> {
     for (index, tensor) in inputs.into_iter().enumerate() {
         let tensor = tensor.downcast::<PyArrayDyn<i8>>()?;
         if !tensor.is_c_contiguous() {
-            return Err(PyErr::new::<PyValueError, _>(
-                "{}th tensor is not C-contiguous".to_string(),
-            ));
+            return Err(PyValueError::new_err(format!("{index}th tensor is not C-contiguous")));
         }
         let slice: &[u8] = unsafe {
             let raw_slice = tensor.as_slice()?;

--- a/src/common/model.rs
+++ b/src/common/model.rs
@@ -10,12 +10,17 @@ pub struct QuantizationParameter {
 pub enum ElementType {
     Float64,
     Int8 { quantization_parameter: QuantizationParameter },
+    Uint8 { quantization_parameter: QuantizationParameter },
 }
 
 impl ElementType {
     pub fn get_scale_and_zero_point(&self) -> (f64, i32) {
-        let ElementType::Int8 { quantization_parameter} = self else {
-            todo!("Currently only supports Int8");
+        let quantization_parameter = match self {
+            ElementType::Int8 { quantization_parameter } => quantization_parameter,
+            ElementType::Uint8 { quantization_parameter } => quantization_parameter,
+            _ => {
+                todo!("Currently only supports Int8/Uint8")
+            }
         };
         (quantization_parameter.scale, quantization_parameter.zero_point)
     }

--- a/src/common/proto.rs
+++ b/src/common/proto.rs
@@ -1,6 +1,147 @@
+pub mod axis {
+    #![allow(clippy::enum_variant_names)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.axis.rs"));
+}
+
+pub mod buffer_type {
+    #![allow(clippy::enum_variant_names)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.buffer_type.rs"));
+}
+
 pub mod common {
     #![allow(clippy::enum_variant_names)]
     include!(concat!(env!("OUT_DIR"), "/npu_ir.common.rs"));
+}
+
+pub mod element_type {
+    #![allow(clippy::enum_variant_names, clippy::module_inception)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.element_type.rs"));
+}
+
+pub mod pass_ops {
+    #![allow(clippy::enum_variant_names)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.pass_ops.rs"));
+}
+
+pub mod shape {
+    #![allow(clippy::enum_variant_names)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.shape.rs"));
+}
+
+pub mod tensor {
+    #![allow(clippy::enum_variant_names)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.tensor.rs"));
+}
+
+pub(crate) mod tu_ops {
+    #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.rs"));
+
+    pub(crate) mod renegade {
+        #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+        include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.renegade.rs"));
+    }
+
+    pub(crate) mod warboy {
+        #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+        include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.warboy.rs"));
+
+        pub(crate) mod commit_unit {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.warboy.commit_unit.rs"));
+        }
+
+        pub(crate) mod fetch_unit {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.warboy.fetch_unit.rs"));
+
+            pub(crate) mod fetch_network {
+                #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/npu_ir.tu_ops.warboy.fetch_unit.fetch_network.rs"
+                ));
+            }
+
+            pub(crate) mod fetch_sequencer {
+                #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/npu_ir.tu_ops.warboy.fetch_unit.fetch_sequencer.rs"
+                ));
+            }
+        }
+
+        pub(crate) mod global_adder_tree {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.warboy.global_adder_tree.rs"));
+        }
+
+        pub(crate) mod load_register_file {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.warboy.load_register_file.rs"));
+        }
+
+        pub(crate) mod load_tensor_register_file {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(
+                env!("OUT_DIR"),
+                "/npu_ir.tu_ops.warboy.load_tensor_register_file.rs"
+            ));
+        }
+
+        pub(crate) mod load_vector_register_file {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(
+                env!("OUT_DIR"),
+                "/npu_ir.tu_ops.warboy.load_vector_register_file.rs"
+            ));
+        }
+
+        pub(crate) mod operation_unit {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.warboy.operation_unit.rs"));
+
+            pub(crate) mod dot_product_engine {
+                #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/npu_ir.tu_ops.warboy.operation_unit.dot_product_engine.rs"
+                ));
+            }
+
+            pub(crate) mod feed_buffer {
+                #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/npu_ir.tu_ops.warboy.operation_unit.feed_buffer.rs"
+                ));
+            }
+
+            pub(crate) mod tensor_register_file_sequencer {
+                #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+                include!(concat!(
+                    env!("OUT_DIR"),
+                    "/npu_ir.tu_ops.warboy.operation_unit.tensor_register_file_sequencer.rs"
+                ));
+            }
+        }
+
+        pub(crate) mod transpose_engine {
+            #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+            include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_ops.warboy.transpose_engine.rs"));
+        }
+    }
+}
+
+pub(crate) mod tu_contraction {
+    #![allow(clippy::enum_variant_names, clippy::derive_partial_eq_without_eq)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.tu_contraction.rs"));
+}
+
+pub mod operator {
+    #![allow(clippy::enum_variant_names)]
+    include!(concat!(env!("OUT_DIR"), "/npu_ir.operator.rs"));
 }
 
 pub mod dfg {

--- a/src/resnet50/mod.rs
+++ b/src/resnet50/mod.rs
@@ -47,7 +47,7 @@ impl PostProcessor {
     #[new]
     fn new(dfg: &[u8]) -> PyResult<Self> {
         let graph = create_graph_from_binary_with_header(dfg)
-            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {}", e)))?;
+            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {e}")))?;
 
         Ok(Self(Resnet50PostProcessor::new(&graph)))
     }

--- a/src/resnet50/mod.rs
+++ b/src/resnet50/mod.rs
@@ -39,7 +39,6 @@ const OUTPUT_NUM: usize = 1;
 /// Args:
 ///     dfg (bytes): a binary of DFG IR
 #[pyclass]
-#[pyo3(text_signature = "(dfg: bytes)")]
 pub struct PostProcessor(Resnet50PostProcessor);
 
 #[pymethods]
@@ -47,7 +46,7 @@ impl PostProcessor {
     #[new]
     fn new(dfg: &[u8]) -> PyResult<Self> {
         let graph = create_graph_from_binary_with_header(dfg)
-            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {e}")))?;
+            .map_err(|e| PyValueError::new_err(format!("invalid DFG format: {e:?}")))?;
 
         Ok(Self(Resnet50PostProcessor::new(&graph)))
     }
@@ -59,12 +58,10 @@ impl PostProcessor {
     ///
     /// Returns:
     ///     List[PyDetectionResult]: Output tensors
-    #[pyo3(text_signature = "(self, inputs: Sequence[numpy.ndarray])")]
     fn eval(&self, inputs: &PyList) -> PyResult<usize> {
         if inputs.len() != OUTPUT_NUM {
-            return Err(PyErr::new::<PyValueError, _>(format!(
-                "expected {} input tensors but got {}",
-                OUTPUT_NUM,
+            return Err(PyValueError::new_err(format!(
+                "expected {OUTPUT_NUM} input tensors but got {}",
                 inputs.len()
             )));
         }

--- a/src/ssd_large/mod.rs
+++ b/src/ssd_large/mod.rs
@@ -484,7 +484,7 @@ impl RustPostProcessor {
     #[new]
     fn new(dfg: &[u8]) -> PyResult<Self> {
         let graph = create_graph_from_binary_with_header(dfg)
-            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {}", e)))?;
+            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {e}")))?;
 
         Ok(Self(RustPostprocessor::new(&graph)))
     }

--- a/src/ssd_large/mod.rs
+++ b/src/ssd_large/mod.rs
@@ -421,7 +421,7 @@ pub mod cxx {
         #[new]
         fn new(dfg: &[u8]) -> PyResult<Self> {
             let graph = create_graph_from_binary_with_header(dfg)
-                .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {}", e)))?;
+                .map_err(|e| PyValueError::new_err(format!("invalid DFG format: {e:?}")))?;
 
             Ok(Self(CppPostprocessor::new(&graph)))
         }
@@ -433,12 +433,10 @@ pub mod cxx {
         ///
         /// Returns:
         ///     List[PyDetectionResult]: Output tensors
-        #[pyo3(text_signature = "(self, inputs: Sequence[numpy.ndarray])")]
         fn eval(&self, inputs: &PyList) -> PyResult<Vec<PyDetectionResult>> {
             if inputs.len() != OUTPUT_NUM {
-                return Err(PyErr::new::<PyValueError, _>(format!(
-                    "expected {} input tensors but got {}",
-                    OUTPUT_NUM,
+                return Err(PyValueError::new_err(format!(
+                    "expected {OUTPUT_NUM} input tensors but got {}",
                     inputs.len()
                 )));
             }
@@ -462,7 +460,6 @@ pub mod cxx {
     /// Args:
     ///     dfg (bytes): a binary of DFG IR
     #[pyclass]
-    #[pyo3(text_signature = "(dfg: bytes)")]
     pub struct CppPostProcessor(CppPostprocessor);
 }
 
@@ -476,7 +473,6 @@ const OUTPUT_NUM: usize = 12;
 /// Args:
 ///     dfg (bytes): a binary of DFG IR
 #[pyclass]
-#[pyo3(text_signature = "(dfg: bytes)")]
 pub struct RustPostProcessor(RustPostprocessor);
 
 #[pymethods]
@@ -484,7 +480,7 @@ impl RustPostProcessor {
     #[new]
     fn new(dfg: &[u8]) -> PyResult<Self> {
         let graph = create_graph_from_binary_with_header(dfg)
-            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {e}")))?;
+            .map_err(|e| PyValueError::new_err(format!("invalid DFG format: {e:?}")))?;
 
         Ok(Self(RustPostprocessor::new(&graph)))
     }
@@ -496,12 +492,10 @@ impl RustPostProcessor {
     ///
     /// Returns:
     ///     List[PyDetectionResult]: Output tensors
-    #[pyo3(text_signature = "(self, inputs: Sequence[numpy.ndarray])")]
     fn eval(&self, inputs: &PyList) -> PyResult<Vec<PyDetectionResult>> {
         if inputs.len() != OUTPUT_NUM {
-            return Err(PyErr::new::<PyValueError, _>(format!(
-                "expected {} input tensors but got {}",
-                OUTPUT_NUM,
+            return Err(PyValueError::new_err(format!(
+                "expected {OUTPUT_NUM} input tensors but got {}",
                 inputs.len()
             )));
         }

--- a/src/ssd_small/mod.rs
+++ b/src/ssd_small/mod.rs
@@ -381,7 +381,7 @@ pub mod cxx {
         #[new]
         fn new(dfg: &[u8]) -> PyResult<Self> {
             let graph = create_graph_from_binary_with_header(dfg)
-                .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {}", e)))?;
+                .map_err(|e| PyValueError::new_err(format!("invalid DFG format: {e:?}")))?;
 
             Ok(Self(CppPostprocessor::new(&graph)))
         }
@@ -393,12 +393,10 @@ pub mod cxx {
         ///
         /// Returns:
         ///     List[PyDetectionResult]: Output tensors
-        #[pyo3(text_signature = "(self, inputs: Sequence[numpy.ndarray])")]
         fn eval(&self, inputs: &PyList) -> PyResult<Vec<PyDetectionResult>> {
             if inputs.len() != OUTPUT_NUM {
-                return Err(PyErr::new::<PyValueError, _>(format!(
-                    "expected {} input tensors but got {}",
-                    OUTPUT_NUM,
+                return Err(PyValueError::new_err(format!(
+                    "expected {OUTPUT_NUM} input tensors but got {}",
                     inputs.len()
                 )));
             }
@@ -422,7 +420,6 @@ pub mod cxx {
     /// Args:
     ///     dfg (bytes): a binary of DFG IR
     #[pyclass]
-    #[pyo3(text_signature = "(dfg: bytes)")]
     pub struct CppPostProcessor(CppPostprocessor);
 }
 
@@ -436,7 +433,6 @@ const OUTPUT_NUM: usize = 12;
 /// Args:
 ///     dfg (bytes): a binary of DFG IR
 #[pyclass]
-#[pyo3(text_signature = "(dfg: bytes)")]
 pub struct RustPostProcessor(RustPostprocessor);
 
 #[pymethods]
@@ -444,7 +440,7 @@ impl RustPostProcessor {
     #[new]
     fn new(dfg: &[u8]) -> PyResult<Self> {
         let graph = create_graph_from_binary_with_header(dfg)
-            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {e}")))?;
+            .map_err(|e| PyValueError::new_err(format!("invalid DFG format: {e:?}")))?;
 
         Ok(Self(RustPostprocessor::new(&graph)))
     }
@@ -456,12 +452,10 @@ impl RustPostProcessor {
     ///
     /// Returns:
     ///     List[PyDetectionResult]: Output tensors
-    #[pyo3(text_signature = "(self, inputs: Sequence[numpy.ndarray])")]
     fn eval(&self, inputs: &PyList) -> PyResult<Vec<PyDetectionResult>> {
         if inputs.len() != OUTPUT_NUM {
-            return Err(PyErr::new::<PyValueError, _>(format!(
-                "expected {} input tensors but got {}",
-                OUTPUT_NUM,
+            return Err(PyValueError::new_err(format!(
+                "expected {OUTPUT_NUM} input tensors but got {}",
                 inputs.len()
             )));
         }

--- a/src/ssd_small/mod.rs
+++ b/src/ssd_small/mod.rs
@@ -444,7 +444,7 @@ impl RustPostProcessor {
     #[new]
     fn new(dfg: &[u8]) -> PyResult<Self> {
         let graph = create_graph_from_binary_with_header(dfg)
-            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {}", e)))?;
+            .map_err(|e| PyErr::new::<PyValueError, _>(format!("invalid DFG format: {e}")))?;
 
         Ok(Self(RustPostprocessor::new(&graph)))
     }

--- a/src/yolov5/mod.rs
+++ b/src/yolov5/mod.rs
@@ -195,11 +195,9 @@ impl RustPostprocessor {
 /// It takes anchors, class_names, strides as input
 ///
 /// Args:
-///     anchors (numpy.ndarray)
-///     num_classes (int)
-///     strides (numpy.ndarray)
+///     anchors (numpy.ndarray): Anchors (3D Array)
+///     strides (numpy.ndarray): Strides (1D Array)
 #[pyclass]
-#[pyo3(text_signature = "(anchors: numpy.ndarray, num_classes: int, strides: numpy.ndarray)")]
 pub struct RustPostProcessor(RustPostprocessor);
 
 #[pymethods]
@@ -222,10 +220,10 @@ impl RustPostProcessor {
     /// Args:
     ///     inputs (Sequence[numpy.ndarray]): Input tensors
     ///     conf_threshold (float): Confidence threshold
+    ///     iou_threshold (float): IoU threshold
     ///
     /// Returns:
     ///     List[numpy.ndarray]: Batched detection results
-    /// #[pyo3(text_signature = "(self, inputs: Sequence[numpy.ndarray], conf_threshold: float)")]
     fn eval(
         &self,
         inputs: Vec<PyReadonlyArray5<'_, f32>>,

--- a/src/yolov5/mod.rs
+++ b/src/yolov5/mod.rs
@@ -34,8 +34,7 @@ impl RustPostprocessor {
         assert_eq!(
             anchors.shape()[2],
             NUM_ANCHOR_LAST,
-            "anchors' last dimension must be {}",
-            NUM_ANCHOR_LAST
+            "anchors' last dimension must be {NUM_ANCHOR_LAST}"
         );
         Self { anchors, strides }
     }


### PR DESCRIPTION
Changes:
- Update rust toolchain (use internally common one)
- Update crate dependencies
- Follow new PyO3 APIs
  - Remove `pyo3(text_signature)`
  - Use `SomeError::new_err`
- Update protobuf hierarchies (similar issue [rt#197](https://github.com/furiosa-ai/furiosa-runtime/pull/197))
- Follow other software components' version (0.9.0)
- Support uint8 type as well